### PR TITLE
Feature/dsansible 76/setup read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ The content in this collection supports Python 3.6 and newer.
 ## Getting started
 
 Clone the repository, and then add it to your PYTHONPATH directory. The Python client is then ready for import and use.
-The library is also available to install using pip.  The pypi project can be found here-> https://pypi.org/project/pyds8k/
+The library is also available to install using pip.  The pypi project can be found at the following link: 
+
+https://pypi.org/project/pyds8k/
 
 To install via pip run the following command:
 ```pip install pyds8k```
@@ -21,6 +23,7 @@ To install via pip run the following command:
 ## Documentation
 Documentation for the pyds8k library can be generated using sphinx.
 The documentation for the latest release is also available via read the docs at the following link:
+
 https://pyds8k.readthedocs.io/en/latest/
 
 NOTE: To view older versions of the doc, click on the link at the bottom right corner in the readthedocs link and select the desired version.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # DS8000 Python Client
 
 [![Build Status](https://travis-ci.com/IBM/pyds8k.svg?branch=develop)](https://travis-ci.com/IBM/pyds8k)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5884/badge)](https://bestpractices.coreinfrastructure.org/projects/5884)
+[![Documentation Status](https://readthedocs.org/projects/pyds8k/badge/?version=latest)](https://pyds8k.readthedocs.io/en/latest/?badge=latest)
 
 This repository contains the IBM RESTful API Python client, which establishes terminal connection with IBM DS8000 storage systems. The Python client protocol enables full management and monitoring of these storage arrays by issuing dedicated RESTful APIs.
 
@@ -11,6 +13,17 @@ The content in this collection supports Python 3.6 and newer.
 ## Getting started
 
 Clone the repository, and then add it to your PYTHONPATH directory. The Python client is then ready for import and use.
+The library is also available to install using pip.  The pypi project can be found here-> https://pypi.org/project/pyds8k/
+
+To install via pip run the following command:
+```pip install pyds8k```
+
+## Documentation
+Documentation for the pyds8k library can be generated using sphinx.
+The documentation for the latest release is also available via read the docs at the following link:
+https://pyds8k.readthedocs.io/en/latest/
+
+NOTE: To view older versions of the doc, click on the link at the bottom right corner in the readthedocs link and select the desired version.
 
 ## Usage examples
 

--- a/README.md
+++ b/README.md
@@ -13,18 +13,14 @@ The content in this collection supports Python 3.6 and newer.
 ## Getting started
 
 Clone the repository, and then add it to your PYTHONPATH directory. The Python client is then ready for import and use.
-The library is also available to install using pip.  The pypi project can be found at the following link: 
-
-https://pypi.org/project/pyds8k/
+The library is also available to install using pip.  See [the pypi pyds8k project](https://pypi.org/project/pyds8k/)
 
 To install via pip run the following command:
 ```pip install pyds8k```
 
 ## Documentation
 Documentation for the pyds8k library can be generated using sphinx.
-The documentation for the latest release is also available via read the docs at the following link:
-
-https://pyds8k.readthedocs.io/en/latest/
+The documentation for the latest release is also available via [pyds8k.readthedocs.io](https://pyds8k.readthedocs.io/en/latest)
 
 NOTE: To view older versions of the doc, click on the link at the bottom right corner in the readthedocs link and select the desired version.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,8 +99,7 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
+if on_rtd:  # only import and set the theme if we're building docs locally
     html_theme = 'sphinx_rtd_theme'
 else:
     html_theme = 'alabaster'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,16 +22,28 @@ import pyds8k
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
+
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.coverage',
-    'sphinx.ext.todo',
-    'sphinx.ext.napoleon',
-    'sphinx_rtd_theme'
-]
+if on_rtd:
+    extensions = [
+        'sphinx.ext.autodoc',
+        'sphinx.ext.viewcode',
+        'sphinx.ext.coverage',
+        'sphinx.ext.todo',
+        'sphinx.ext.napoleon',
+        'sphinx_rtd_theme'
+    ]
+else:
+    extensions = [
+        'sphinx.ext.autodoc',
+        'sphinx.ext.viewcode',
+        'sphinx.ext.coverage',
+        'sphinx.ext.todo',
+        'sphinx.ext.napoleon'
+    ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -97,7 +109,6 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if on_rtd:  # only import and set the theme if we're building docs locally
     html_theme = 'sphinx_rtd_theme'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.realpath(os.path.abspath('../')))
 sys.path.append(os.path.abspath('../..'))
 
 import pyds8k
+import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -29,7 +30,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.coverage',
     'sphinx.ext.todo',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'sphinx_rtd_theme'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -96,7 +98,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,13 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+else:
+    html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,6 @@ sys.path.insert(0, os.path.realpath(os.path.abspath('../')))
 sys.path.append(os.path.abspath('../..'))
 
 import pyds8k
-import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -1,0 +1,11 @@
+# File: docs/environment.yaml
+
+name: docs
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - sphinx==4.2.0
+  - nbsphinx==0.8.1
+  - pip:
+    - sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+# File: docs/requirements.txt
+
+# Defining the exact version will make sure things don't break
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0


### PR DESCRIPTION
Alright...think I got around the travis ci build issues.  Should build with the read the docs theme when doc is built in a READ THE DOCS environment, otherwise will use alabaster theme.