### PR TITLE
DSANSIBLE-78

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,8 +7,13 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.realpath(os.path.abspath('../')))
-sys.path.append(os.path.abspath('../..'))
+sys.path.insert(
+    0,
+    os.path.realpath(
+        os.path.abspath(f"..{os.sep}")
+    )
+)
+sys.path.append(os.path.abspath(f"..{os.sep}.."))
 
 import pyds8k
 

--- a/pyds8k/base.py
+++ b/pyds8k/base.py
@@ -81,7 +81,7 @@ def get_resource_route_prefix_by_class(cls):
     path = os.path.abspath(
         os.path.dirname(sys.modules[cls.__module__].__file__)
     )
-    route = path.replace("/", ".")
+    route = path.replace(os.sep, ".")
     return route.rsplit(".resources.", 2)[1]
 
 


### PR DESCRIPTION
to Support Win
1) change hard coded path separator to os.sep
~~2) add osx, windows into .travis.yml~~
travisci does not support python on windows yet.

Signed-off-by: shipeng@us.ibm.com <shipeng@us.ibm.com>