### PR TITLE
DSANSIBLE-98 Migrate to pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = pyds8k/test/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,10 @@ jobs:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-    - python: 3.7
-      env: TOXENV=cover,docs,flake8
     - python: 3.8
       env: TOXENV=py38
     - python: 3.9
-      env: TOXENV=py39
+      env: TOXENV=cover,docs,flake8
     - python: "3.10"
       dist: focal
       env: TOXENV=py310

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 # ref: https://docs.travis-ci.com/user/languages/python
 language: python
+os: linux
 dist: xenial
 
-matrix:
-    include:
-     - python: 3.6
-       env: TOXENV=py36
-     - python: 3.7
-       env: TOXENV=py37
-     - python: 3.7
-       env: TOXENV=cover,docs,flake8
-     - python: 3.8
-       env: TOXENV=py38
-
+jobs:
+  include:
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.7
+      env: TOXENV=cover,docs,flake8
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
+    - python: "3.10"
+      dist: focal
+      env: TOXENV=py310
 install:
   - pip install tox
 

--- a/pyds8k/test/integration/integration.py
+++ b/pyds8k/test/integration/integration.py
@@ -17,8 +17,8 @@
 from functools import wraps, partial
 from logging import getLogger
 from contextlib import contextmanager
+import pytest
 import unittest
-from nose.tools import nottest
 from datetime import datetime
 from pyds8k import PYDS8K_DEFAULT_LOGGER
 from pyds8k.utils import res_timer_recorder
@@ -164,8 +164,7 @@ class TestIntegration(unittest.TestCase):
             if vols:
                 return
 
-    # Skipped, because get all volumes is not allowed.
-    @nottest
+    @pytest.mark.skip(reason="get all volumes is not allowed.")
     def test_volumes(self):
         volumes = self.get_volumes()
         self.get_volumes(volumes[0].id)

--- a/pyds8k/test/test_httpclient.py
+++ b/pyds8k/test/test_httpclient.py
@@ -18,8 +18,8 @@ from pyds8k.exceptions import URLParseError
 from . import base
 import httpretty
 import json
+import pytest
 import time
-from nose.tools import nottest
 from pyds8k.httpclient import HTTPClient
 from pyds8k.base import Resource, DefaultManager
 from .data import get_response_list_json_by_type, \
@@ -77,8 +77,7 @@ class TestHTTPClient(base.TestCaseWithConnect):
         de = self.resource.one(DEFAULT, 'old').get(allow_redirects=False)
         self.assertEqual(new_url, de.url)
 
-    # Not work in this way.
-    @nottest
+    @pytest.mark.skip(reason="Not work in this way")
     @httpretty.activate
     def test_timeout(self):
         url = '/default/a'

--- a/pyds8k/test/test_resources/test_ds8k/test_flashcopies.py
+++ b/pyds8k/test/test_resources/test_ds8k/test_flashcopies.py
@@ -35,10 +35,10 @@ class TestFlashCopies(TestDS8KWithConnect):
                                    }],
                  "options": []
                  })
-            self.assertDictContainsSubset(
-                req.get_request_data().get('request').get('params'),
-                json.loads(request.body).get('request').get('params'),
-            )
+            assert {
+                    **json.loads(request.body).get('request').get('params'),
+                    **req.get_request_data().get('request').get('params')
+                    } == json.loads(request.body).get('request').get('params')
             return (201, headers, create_flashcopy_response_json)
 
         httpretty.register_uri(httpretty.POST,

--- a/pyds8k/test/test_resources/test_ds8k/test_host.py
+++ b/pyds8k/test/test_resources/test_ds8k/test_host.py
@@ -16,7 +16,7 @@
 
 import httpretty
 import json
-from nose.tools import nottest
+import pytest
 from functools import cmp_to_key
 import warnings
 from pyds8k.exceptions import InternalServerError, FieldReadOnly
@@ -214,7 +214,7 @@ class TestHost(TestDS8KWithConnect):
         self.assertEqual(httpretty.PUT, httpretty.last_request().method)
         self.assertEqual(resp1, action_response['server'])
 
-    @nottest
+    @pytest.mark.skip()
     @httpretty.activate
     def test_update_host_rm_volumes_all(self):
         host_name = 'host1'
@@ -252,12 +252,12 @@ class TestHost(TestDS8KWithConnect):
         self.assertEqual(data2, action_response['server'])
         self.assertEqual(resp2.status_code, 200)
 
-    @nottest
+    @pytest.mark.skip()
     @httpretty.activate
     def test_update_host_add_volumes(self):
         warnings.warn('test_update_host_add_volumes: not finished yet.')
 
-    @nottest
+    @pytest.mark.skip()
     @httpretty.activate
     def test_update_host_rm_volumes(self):
         warnings.warn('test_update_host_rm_volumes: not finished yet.')
@@ -537,10 +537,10 @@ class TestHost(TestDS8KWithConnect):
             self.assertEqual(uri, self.domain + self.base_url + url)
 
             req = RequestParser({'hosttype': host_type, 'name': host_name})
-            self.assertDictContainsSubset(
-                req.get_request_data().get('request').get('params'),
-                json.loads(request.body).get('request').get('params'),
-            )
+            assert {
+                    **json.loads(request.body).get('request').get('params'),
+                    **req.get_request_data().get('request').get('params')
+                    } == json.loads(request.body).get('request').get('params')
             return (200, headers, create_host_response_json)
 
         httpretty.register_uri(httpretty.POST,

--- a/pyds8k/test/test_resources/test_ds8k/test_host_port.py
+++ b/pyds8k/test/test_resources/test_ds8k/test_host_port.py
@@ -232,10 +232,10 @@ class TestHostPort(TestDS8KWithConnect):
             self.assertEqual(uri, self.domain + self.base_url + url)
 
             req = RequestParser({'wwpn': self.wwpn, 'host': host_name})
-            self.assertDictContainsSubset(
-                req.get_request_data().get('request').get('params'),
-                json.loads(request.body).get('request').get('params'),
-            )
+            assert {
+                    **json.loads(request.body).get('request').get('params'),
+                    **req.get_request_data().get('request').get('params')
+                    } == json.loads(request.body).get('request').get('params')
             return (200, headers, create_host_port_response_json)
 
         httpretty.register_uri(httpretty.POST,

--- a/pyds8k/test/test_resources/test_ds8k/test_lss.py
+++ b/pyds8k/test/test_resources/test_ds8k/test_lss.py
@@ -165,10 +165,10 @@ class TestLSS(TestDS8KWithConnect):
             )
 
             req = RequestParser(struct_request)
-            self.assertDictContainsSubset(
-                req.get_request_data().get('request').get('params'),
-                json.loads(request.body).get('request').get('params')
-            )
+            assert {
+                    **json.loads(request.body).get('request').get('params'),
+                    **req.get_request_data().get('request').get('params')
+                   } == json.loads(request.body).get('request').get('params')
             return 201, headers, json.dumps(create_lss_response)
 
         httpretty.register_uri(

--- a/pyds8k/test/test_resources/test_ds8k/test_root_resource_mixin.py
+++ b/pyds8k/test/test_resources/test_ds8k/test_root_resource_mixin.py
@@ -15,7 +15,7 @@
 ##############################################################################
 
 import httpretty
-from nose.tools import nottest
+import pytest
 from pyds8k.resources.ds8k.v1.common import types
 from pyds8k.test.data import get_response_list_json_by_type, \
     get_response_list_data_by_type, \
@@ -157,14 +157,14 @@ class TestRootResourceMixin(TestDS8KWithConnect):
     def test_get_flashcopies(self):
         self._test_resource_list_by_route(types.DS8K_FLASHCOPY)
 
-    @nottest
+    @pytest.mark.skip()
     def test_get_flashcopy(self):
         self._test_resource_by_route(types.DS8K_FLASHCOPY)
 
     def test_get_pprc(self):
         self._test_resource_list_by_route(types.DS8K_PPRC)
 
-    @nottest
+    @pytest.mark.skip()
     def test_get_pprc_by_id(self):
         self._test_resource_by_route(types.DS8K_PPRC)
 

--- a/pyds8k/test/test_resources/test_ds8k/test_volume.py
+++ b/pyds8k/test/test_resources/test_ds8k/test_volume.py
@@ -17,7 +17,7 @@
 import json
 
 import httpretty
-from nose.tools import nottest
+import pytest
 
 from pyds8k.dataParser.ds8k import RequestParser
 from pyds8k.exceptions import FieldReadOnly
@@ -251,7 +251,7 @@ class TestVolume(TestDS8KWithConnect):
         self.assertEqual(httpretty.PUT, httpretty.last_request().method)
         self.assertEqual(body, action_response['server'])
 
-    @nottest
+    @pytest.mark.skip()
     @httpretty.activate
     def test_update_volume_map(self):
         volume_id = 'a_0000'
@@ -298,10 +298,10 @@ class TestVolume(TestDS8KWithConnect):
                                  'captype': captype, 'lss': lss, 'tp': tp,
                                  }
                                 )
-            self.assertDictContainsSubset(
-                req.get_request_data().get('request').get('params'),
-                json.loads(request.body).get('request').get('params'),
-            )
+            assert {
+                    **json.loads(request.body).get('request').get('params'),
+                    **req.get_request_data().get('request').get('params')
+                   } == json.loads(request.body).get('request').get('params')
             return (201, headers, create_volume_response_json)
 
         httpretty.register_uri(httpretty.POST,
@@ -522,10 +522,10 @@ class TestVolume(TestDS8KWithConnect):
                 'id': id
             })
 
-            self.assertDictContainsSubset(
-                req.get_request_data().get('request').get('params'),
-                json.loads(request.body).get('request').get('params'),
-            )
+            assert {
+                    **json.loads(request.body).get('request').get('params'),
+                    **req.get_request_data().get('request').get('params')
+                   } == json.loads(request.body).get('request').get('params')
 
             prepared_response = create_volume_response.copy()
             prepared_response['data']['volumes'][0]['id'] = id
@@ -616,10 +616,7 @@ class TestVolume(TestDS8KWithConnect):
 
             self.assertEqual(req_name_col, rec_namecol)
 
-            self.assertDictContainsSubset(
-                prepared_request,
-                received_request,
-            )
+            assert {**received_request, **prepared_request} == received_request
 
             prepared_response = create_volume_response.copy()
             prepared_response['data']['volumes'][0]['id'] = ids[0]

--- a/pyds8k/test/test_utils.py
+++ b/pyds8k/test/test_utils.py
@@ -15,7 +15,7 @@
 ##############################################################################
 
 from . import base
-from nose.tools import nottest
+import pytest
 from pyds8k import utils
 
 
@@ -67,7 +67,7 @@ class TestUtils(base.TestCaseWithoutConnect):
     # def test_get_default_service_type(self):
     #     self.assertEqual('ds8k', utils.get_default_service_type())
 
-    @nottest
+    @pytest.mark.skip()
     def test_get_config_settings(self):
         settings_dict = utils.get_config_settings()
         self.assertEqual(5, len(list(settings_dict.keys())))
@@ -76,7 +76,7 @@ class TestUtils(base.TestCaseWithoutConnect):
         self.assertIsNotNone(settings_dict.get('default_service_type'))
         self.assertIsNotNone(settings_dict.get('runtime_service_type'))
 
-    @nottest
+    @pytest.mark.skip()
     def test_get_config_all_items(self):
         config_dict = utils.get_config_all_items()
         self.assertEqual(5, len(list(config_dict.keys())))
@@ -85,7 +85,7 @@ class TestUtils(base.TestCaseWithoutConnect):
         self.assertIsNotNone(config_dict.get('default_service_type'))
         self.assertIsNotNone(config_dict.get('runtime_service_type'))
 
-    @nottest
+    @pytest.mark.skip()
     def test_get_config_all(self):
         config_dict = utils.get_config_all()
         self.assertEqual(1, len(list(config_dict.keys())))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest>=7.1.2
+pytest>=7.0.0
 pytest-cov>=3.0.0
 mock>=3.0.5
 flake8>=3.6.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
-nose>=1.3.7
+pytest>=7.1.2
+pytest-cov>=3.0.0
 mock>=3.0.5
 flake8>=3.6.0
 sphinx>=2.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.14.3
 skipdist = True
-envlist = py3{6,7,8},flake8,cover,docs
+envlist = py3{6,7,8,9,10},flake8,cover,docs
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
@@ -11,13 +11,13 @@ install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
-  nosetests -v --exe {posargs}
+  pytest --disable-warnings -v {posargs}
 
 [testenv:cover]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
-  nosetests --with-coverage --cover-package=pyds8k --cover-html -v {posargs}
+  pytest --cov-config=.coveragerc --cov pyds8k --disable-warnings -v {posargs}
 
 [testenv:docs]
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Convert to pytest as nose is unmaintained and [doesn't work with >python3.9](https://github.com/nose-devs/nose/issues/1099)
Add python3.9 and 3.10 to travis and tox
Remove duplicate run with cover and py37
Move cover,docs,flake8 to python3.9