### PR TITLE
Remove six dependancy

### DIFF
--- a/pyds8k/base.py
+++ b/pyds8k/base.py
@@ -224,7 +224,6 @@ class Resource(UtilsMixin, BaseResource):
 
     def create(self, **kwargs):
         custom_info = {}
-        # for (k, v) in six.iteritems(info):
         for (k, v) in kwargs.items():
             if k in list(self._template.keys()):
                 custom_info[k] = v
@@ -320,7 +319,6 @@ class Resource(UtilsMixin, BaseResource):
         self_url = self.ResponseParser.get_link_from_representation(info)
         if self_url:
             self.url = self_url
-        # for (k, v) in six.iteritems(info):
         for (k, v) in info.items():
             if not force and k in list(self._modified_info_dict.keys()):
                 continue

--- a/pyds8k/dataParser/base.py
+++ b/pyds8k/dataParser/base.py
@@ -16,11 +16,8 @@
 
 from abc import ABCMeta, abstractmethod
 
-import six
 
-
-@six.add_metaclass(ABCMeta)
-class BaseRequestParser(object):
+class BaseRequestParser(object, metaclass=ABCMeta):
     # Parse the data user wants to send to server,
     # in the right format that server defined.
 
@@ -33,8 +30,7 @@ class BaseRequestParser(object):
         pass
 
 
-@six.add_metaclass(ABCMeta)
-class BaseResponseParser(object):
+class BaseResponseParser(object, metaclass=ABCMeta):
     # Parser response data, to get resource link, representation, etc.
 
     response_key = ''

--- a/pyds8k/resources/ds8k/v1/cs/flashcopies.py
+++ b/pyds8k/resources/ds8k/v1/cs/flashcopies.py
@@ -17,15 +17,13 @@
 """
 advanced FlashCopies interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from ..common.base import Base, BaseManager
 from ..common.types import DS8K_CS_FLASHCOPY, DS8K_FLASHCOPY
 from ..volumes import Volume, VolumeManager
 
 
-@six.add_metaclass(ResourceMeta)
-class FlashCopy(Base):
+class FlashCopy(Base, metaclass=ResourceMeta):
     resource_type = DS8K_CS_FLASHCOPY
     _template = {'id': None,
                  'persistent': None,
@@ -51,8 +49,7 @@ class FlashCopy(Base):
             self._id = info[DS8K_FLASHCOPY][0]['id']
 
 
-@six.add_metaclass(ManagerMeta)
-class FlashCopyManager(BaseManager):
+class FlashCopyManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage advanced FlashCopies resources.
     """

--- a/pyds8k/resources/ds8k/v1/cs/pprcs.py
+++ b/pyds8k/resources/ds8k/v1/cs/pprcs.py
@@ -17,7 +17,6 @@
 """
 advanced PPRC interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from ..common.base import Base, ReadOnlyManager
 from ..common.types import DS8K_CS_PPRC
@@ -25,8 +24,7 @@ from ..volumes import Volume, VolumeManager
 from ..systems import System, SystemManager
 
 
-@six.add_metaclass(ResourceMeta)
-class PPRC(Base):
+class PPRC(Base, metaclass=ResourceMeta):
     resource_type = DS8K_CS_PPRC
 
     _template = {'id': '',
@@ -60,8 +58,7 @@ class PPRC(Base):
         super(PPRC, self)._add_details(info, force=force)
 
 
-@six.add_metaclass(ManagerMeta)
-class PPRCManager(ReadOnlyManager):
+class PPRCManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage advanced PPRC resources.
     """

--- a/pyds8k/resources/ds8k/v1/encryption_groups.py
+++ b/pyds8k/resources/ds8k/v1/encryption_groups.py
@@ -17,15 +17,13 @@
 """
 Encryption Group interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 
 from .common.base import Base, ReadOnlyManager
 from .common.types import DS8K_ENCRYPTION_GROUP
 
 
-@six.add_metaclass(ResourceMeta)
-class EncryptionGroup(Base):
+class EncryptionGroup(Base, metaclass=ResourceMeta):
     resource_type = DS8K_ENCRYPTION_GROUP
     # id_field = 'id'
     _template = {'id': '',
@@ -33,8 +31,7 @@ class EncryptionGroup(Base):
                  }
 
 
-@six.add_metaclass(ManagerMeta)
-class EncryptionGroupManager(ReadOnlyManager):
+class EncryptionGroupManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage Encryption Group resources.
     """

--- a/pyds8k/resources/ds8k/v1/eserep.py
+++ b/pyds8k/resources/ds8k/v1/eserep.py
@@ -17,15 +17,13 @@
 """
 ESE Rep interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_ESEREP
 from .common.base import SingletonBase, SingletonBaseManager
 from .pools import Pool, PoolManager
 
 
-@six.add_metaclass(ResourceMeta)
-class ESERep(SingletonBase):
+class ESERep(SingletonBase, metaclass=ResourceMeta):
     resource_type = DS8K_ESEREP
     # id_field = 'id'
     _template = {'cap': '',
@@ -45,8 +43,7 @@ class ESERep(SingletonBase):
         return super(ESERep, self).__getattr__(key)
 
 
-@six.add_metaclass(ManagerMeta)
-class ESERepManager(SingletonBaseManager):
+class ESERepManager(SingletonBaseManager, metaclass=ManagerMeta):
     """
     Manage ESE Rep resources.
     """

--- a/pyds8k/resources/ds8k/v1/events.py
+++ b/pyds8k/resources/ds8k/v1/events.py
@@ -17,14 +17,12 @@
 """
 Event interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_EVENT
 from .common.base import Base, ReadOnlyManager
 
 
-@six.add_metaclass(ResourceMeta)
-class Event(Base):
+class Event(Base, metaclass=ResourceMeta):
     resource_type = DS8K_EVENT
     # id_field = 'id'
     _template = {'id': '',
@@ -37,8 +35,7 @@ class Event(Base):
                  }
 
 
-@six.add_metaclass(ManagerMeta)
-class EventManager(ReadOnlyManager):
+class EventManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage Event resources.
     """

--- a/pyds8k/resources/ds8k/v1/flashcopy.py
+++ b/pyds8k/resources/ds8k/v1/flashcopy.py
@@ -17,15 +17,13 @@
 """
 FlashCopy interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.base import Base, ReadOnlyManager
 from .common.types import DS8K_FLASHCOPY
 from .volumes import Volume, VolumeManager
 
 
-@six.add_metaclass(ResourceMeta)
-class FlashCopy(Base):
+class FlashCopy(Base, metaclass=ResourceMeta):
     resource_type = DS8K_FLASHCOPY
     # id_field = 'id'
     _template = {'id': '',
@@ -54,8 +52,7 @@ class FlashCopy(Base):
     #    return "<FlashCopy: {}>".format(self.id)
 
 
-@six.add_metaclass(ManagerMeta)
-class FlashCopyManager(ReadOnlyManager):
+class FlashCopyManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage FlashCopy resources.
     """

--- a/pyds8k/resources/ds8k/v1/hmc/certificate/certificate.py
+++ b/pyds8k/resources/ds8k/v1/hmc/certificate/certificate.py
@@ -17,15 +17,13 @@
 """
 Hardware Management Console Certificate interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 
 from ...common.base import Base, BaseManager
 from ...common.types import DS8K_HMC_CERTIFICATE
 
 
-@six.add_metaclass(ResourceMeta)
-class HmcCertificate(Base):
+class HmcCertificate(Base, metaclass=ResourceMeta):
     resource_type = DS8K_HMC_CERTIFICATE
 
     # id_field = ''
@@ -40,8 +38,7 @@ class HmcCertificate(Base):
     #     return "<HMC Certificate: {0}>".format(self.id)
 
 
-@six.add_metaclass(ManagerMeta)
-class HmcCertificateManager(BaseManager):
+class HmcCertificateManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage Hardware Management Console Certificate resources.
     """

--- a/pyds8k/resources/ds8k/v1/hmc/certificate/csr.py
+++ b/pyds8k/resources/ds8k/v1/hmc/certificate/csr.py
@@ -17,15 +17,13 @@
 """
 Hardware Management Console Certificate Signing Request interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 
 from ...common.base import Base, BaseManager
 from ...common.types import DS8K_HMC_CERTIFICATE_CSR
 
 
-@six.add_metaclass(ResourceMeta)
-class HmcCertificateCsr(Base):
+class HmcCertificateCsr(Base, metaclass=ResourceMeta):
     resource_type = DS8K_HMC_CERTIFICATE_CSR
 
     # id_field = ''
@@ -40,8 +38,7 @@ class HmcCertificateCsr(Base):
     #     return "<HMC CSR: {0}>".format(self.id)
 
 
-@six.add_metaclass(ManagerMeta)
-class HmcCertificateCsrManager(BaseManager):
+class HmcCertificateCsrManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage Hardware Management Console Certificate Signing Request resources.
     """

--- a/pyds8k/resources/ds8k/v1/hmc/certificate/selfsigned.py
+++ b/pyds8k/resources/ds8k/v1/hmc/certificate/selfsigned.py
@@ -17,20 +17,17 @@
 """
 Hardware Management Console Self-signed Certificate interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 
 from ...common.base import Base, BaseManager
 from ...common.types import DS8K_HMC_CERTIFICATE_SELFSIGNED
 
 
-@six.add_metaclass(ResourceMeta)
-class HmcCertificateSelfSigned(Base):
+class HmcCertificateSelfSigned(Base, metaclass=ResourceMeta):
     resource_type = DS8K_HMC_CERTIFICATE_SELFSIGNED
 
 
-@six.add_metaclass(ManagerMeta)
-class HmcCertificateSelfSignedManager(BaseManager):
+class HmcCertificateSelfSignedManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage Hardware Management Console Self-signed Certificate resources.
     """

--- a/pyds8k/resources/ds8k/v1/hmc/hmc.py
+++ b/pyds8k/resources/ds8k/v1/hmc/hmc.py
@@ -17,15 +17,13 @@
 """
 Hardware Management Console interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 
 from ..common.base import Base, BaseManager
 from ..common.types import DS8K_HMC
 
 
-@six.add_metaclass(ResourceMeta)
-class HMC(Base):
+class HMC(Base, metaclass=ResourceMeta):
     resource_type = DS8K_HMC
 
     # id_field = ''
@@ -40,8 +38,7 @@ class HMC(Base):
     #     return "<HMC: {0}>".format(self.id)
 
 
-@six.add_metaclass(ManagerMeta)
-class HMCManager(BaseManager):
+class HMCManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage Hardware Management Console resources.
     """

--- a/pyds8k/resources/ds8k/v1/hmc/restart.py
+++ b/pyds8k/resources/ds8k/v1/hmc/restart.py
@@ -17,20 +17,17 @@
 """
 Hardware Management Console Restart interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 
 from ..common.base import Base, BaseManager
 from ..common.types import DS8K_HMC_RESTART
 
 
-@six.add_metaclass(ResourceMeta)
-class HMCRestart(Base):
+class HMCRestart(Base, metaclass=ResourceMeta):
     resource_type = DS8K_HMC_RESTART
 
 
-@six.add_metaclass(ManagerMeta)
-class HMCRestartManager(BaseManager):
+class HMCRestartManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage Hardware Management Console Restart.
     """

--- a/pyds8k/resources/ds8k/v1/host_ports.py
+++ b/pyds8k/resources/ds8k/v1/host_ports.py
@@ -17,7 +17,6 @@
 """
 Host Ports interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_HOST_PORT
 from .common.base import Base, BaseManager
@@ -25,8 +24,7 @@ from .hosts import Host, HostManager
 from .ioports import IOPort, IOPortManager
 
 
-@six.add_metaclass(ResourceMeta)
-class HostPort(Base):
+class HostPort(Base, metaclass=ResourceMeta):
     resource_type = DS8K_HOST_PORT
     id_field = 'wwpn'
     _template = {'wwpn': '',
@@ -68,8 +66,7 @@ class HostPort(Base):
     #    return "<HostPort: {0}>".format(self.id)
 
 
-@six.add_metaclass(ManagerMeta)
-class HostPortManager(BaseManager):
+class HostPortManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage Host Ports resources.
     """

--- a/pyds8k/resources/ds8k/v1/hosts.py
+++ b/pyds8k/resources/ds8k/v1/hosts.py
@@ -17,15 +17,19 @@
 """
 Host interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.base import Base, BaseManager
 from .common.mixins import FCPortMixin, HostPortMixin, VolumeMixin, VolmapMixin
 from .common import types
 
 
-@six.add_metaclass(ResourceMeta)
-class Host(FCPortMixin, HostPortMixin, VolumeMixin, VolmapMixin, Base):
+class Host(FCPortMixin,
+           HostPortMixin,
+           VolumeMixin,
+           VolmapMixin,
+           Base,
+           metaclass=ResourceMeta
+           ):
     resource_type = types.DS8K_HOST
     id_field = 'name'
     alias = {'id': 'host_id'}
@@ -85,8 +89,7 @@ class Host(FCPortMixin, HostPortMixin, VolumeMixin, VolmapMixin, Base):
         return [port.id for port in updated]
 
 
-@six.add_metaclass(ManagerMeta)
-class HostManager(BaseManager):
+class HostManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage Host resources.
     """

--- a/pyds8k/resources/ds8k/v1/io_enclosures.py
+++ b/pyds8k/resources/ds8k/v1/io_enclosures.py
@@ -17,14 +17,12 @@
 """
 IO Enclosure interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_IOENCLOSURE
 from .common.base import Base, ReadOnlyManager
 
 
-@six.add_metaclass(ResourceMeta)
-class IOEnclosure(Base):
+class IOEnclosure(Base, metaclass=ResourceMeta):
     resource_type = DS8K_IOENCLOSURE
     # id_field = 'id'
     _template = {'id': '',
@@ -33,8 +31,7 @@ class IOEnclosure(Base):
                  }
 
 
-@six.add_metaclass(ManagerMeta)
-class IOEnclosureManager(ReadOnlyManager):
+class IOEnclosureManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage IO Enclosure resources.
     """

--- a/pyds8k/resources/ds8k/v1/ioports.py
+++ b/pyds8k/resources/ds8k/v1/ioports.py
@@ -17,15 +17,13 @@
 """
 IO Ports interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_IOPORT
 from .common.base import Base, ReadOnlyManager
 from .io_enclosures import IOEnclosure, IOEnclosureManager
 
 
-@six.add_metaclass(ResourceMeta)
-class IOPort(Base):
+class IOPort(Base, metaclass=ResourceMeta):
     resource_type = DS8K_IOPORT
     # id_field = 'id'
     _template = {'id': '',
@@ -45,8 +43,7 @@ class IOPort(Base):
     #    return "<FCPort: {0}>".format(self.id)
 
 
-@six.add_metaclass(ManagerMeta)
-class IOPortManager(ReadOnlyManager):
+class IOPortManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage IO Ports resources.
     """

--- a/pyds8k/resources/ds8k/v1/lss.py
+++ b/pyds8k/resources/ds8k/v1/lss.py
@@ -17,7 +17,6 @@
 """
 LSS interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_LSS, DS8K_VOLUME, \
     DS8K_LCU_TYPES, \
@@ -28,8 +27,7 @@ from .common.base import Base, BaseManager
 from .common.mixins import VolumeMixin
 
 
-@six.add_metaclass(ResourceMeta)
-class LSS(VolumeMixin, Base):
+class LSS(VolumeMixin, Base, metaclass=ResourceMeta):
     resource_type = DS8K_LSS
     # id_field = 'id'
     _template = {
@@ -91,8 +89,7 @@ class LSS(VolumeMixin, Base):
         return "<Storage LSS: {0}>".format(self._get_id())
 
 
-@six.add_metaclass(ManagerMeta)
-class LSSManager(BaseManager):
+class LSSManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage LSS resources.
     """

--- a/pyds8k/resources/ds8k/v1/mappings.py
+++ b/pyds8k/resources/ds8k/v1/mappings.py
@@ -17,15 +17,13 @@
 """
 Host Volume Mapping interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.base import Base, BaseManager
 from .common.types import DS8K_VOLMAP
 from .volumes import Volume, VolumeManager
 
 
-@six.add_metaclass(ResourceMeta)
-class Volmap(Base):
+class Volmap(Base, metaclass=ResourceMeta):
     resource_type = DS8K_VOLMAP
     id_field = 'lunid'
     _template = {'lunid': '',
@@ -38,8 +36,7 @@ class Volmap(Base):
         return "<Host Volume Mapping: {0}>".format(self._get_id())
 
 
-@six.add_metaclass(ManagerMeta)
-class VolmapManager(BaseManager):
+class VolmapManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage Host Volume Mapping resources.
     """

--- a/pyds8k/resources/ds8k/v1/marrays.py
+++ b/pyds8k/resources/ds8k/v1/marrays.py
@@ -17,15 +17,13 @@
 """
 Marray interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_MARRAY
 from .common.base import Base, ReadOnlyManager
 from .pools import Pool, PoolManager
 
 
-@six.add_metaclass(ResourceMeta)
-class Marray(Base):
+class Marray(Base, metaclass=ResourceMeta):
     resource_type = DS8K_MARRAY
     # id_field = 'id'
     _template = {'id': '',
@@ -37,8 +35,7 @@ class Marray(Base):
                         }
 
 
-@six.add_metaclass(ManagerMeta)
-class MarrayManager(ReadOnlyManager):
+class MarrayManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage Marray resources.
     """

--- a/pyds8k/resources/ds8k/v1/nodes.py
+++ b/pyds8k/resources/ds8k/v1/nodes.py
@@ -17,14 +17,12 @@
 """
 Node interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_NODE
 from .common.base import Base, ReadOnlyManager
 
 
-@six.add_metaclass(ResourceMeta)
-class Node(Base):
+class Node(Base, metaclass=ResourceMeta):
     resource_type = DS8K_NODE
     # id_field = 'id'
     _template = {'id': '',
@@ -32,8 +30,7 @@ class Node(Base):
                  }
 
 
-@six.add_metaclass(ManagerMeta)
-class NodeManager(ReadOnlyManager):
+class NodeManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage LSS resources.
     """

--- a/pyds8k/resources/ds8k/v1/pools.py
+++ b/pyds8k/resources/ds8k/v1/pools.py
@@ -17,7 +17,6 @@
 """
 Extent pool interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_POOL, DS8K_VOLUME, \
     DS8K_TSEREP, DS8K_ESEREP
@@ -28,8 +27,7 @@ from pyds8k.exceptions import IDMissingError
 
 # Note: VolumeMixin will override the methods with
 # same name in RootResourceMixin.
-@six.add_metaclass(ResourceMeta)
-class Pool(VolumeMixin, Base):
+class Pool(VolumeMixin, Base, metaclass=ResourceMeta):
     resource_type = DS8K_POOL
     # id_field = 'id'
     _template = {'id': '',
@@ -113,8 +111,7 @@ class Pool(VolumeMixin, Base):
                         ).update({'threshold': threshold})
 
 
-@six.add_metaclass(ManagerMeta)
-class PoolManager(ReadOnlyManager):
+class PoolManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage Extent Pool resources.
     """

--- a/pyds8k/resources/ds8k/v1/pprc.py
+++ b/pyds8k/resources/ds8k/v1/pprc.py
@@ -17,7 +17,6 @@
 """
 PPRC interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.base import Base, ReadOnlyManager
 from .common.types import DS8K_PPRC
@@ -25,8 +24,7 @@ from .volumes import Volume, VolumeManager
 from .systems import System, SystemManager
 
 
-@six.add_metaclass(ResourceMeta)
-class PPRC(Base):
+class PPRC(Base, metaclass=ResourceMeta):
     resource_type = DS8K_PPRC
     # id_field = 'id'
     _template = {'id': '',
@@ -55,8 +53,7 @@ class PPRC(Base):
     #    return "<FlashCopy: {}>".format(self.id)
 
 
-@six.add_metaclass(ManagerMeta)
-class PPRCManager(ReadOnlyManager):
+class PPRCManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage PPRC resources.
     """

--- a/pyds8k/resources/ds8k/v1/resource_groups.py
+++ b/pyds8k/resources/ds8k/v1/resource_groups.py
@@ -17,15 +17,13 @@
 """
 Resource Group interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 
 from .common.base import Base, BaseManager
 from .common.types import DS8K_RESOURCE_GROUP
 
 
-@six.add_metaclass(ResourceMeta)
-class ResourceGroup(Base):
+class ResourceGroup(Base, metaclass=ResourceMeta):
     resource_type = DS8K_RESOURCE_GROUP
     # id_field = 'id'
 
@@ -41,8 +39,7 @@ class ResourceGroup(Base):
     }
 
 
-@six.add_metaclass(ManagerMeta)
-class ResourceGroupManager(BaseManager):
+class ResourceGroupManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage Resource Group resources.
     """

--- a/pyds8k/resources/ds8k/v1/systems.py
+++ b/pyds8k/resources/ds8k/v1/systems.py
@@ -17,14 +17,12 @@
 """
 Storage system interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_SYSTEM
 from .common.base import Base, ReadOnlyManager
 
 
-@six.add_metaclass(ResourceMeta)
-class System(Base):
+class System(Base, metaclass=ResourceMeta):
     resource_type = DS8K_SYSTEM
     id_field = 'id'
     _template = {'id': '',
@@ -48,8 +46,7 @@ class System(Base):
         return self.get_systems()[0]
 
 
-@six.add_metaclass(ManagerMeta)
-class SystemManager(ReadOnlyManager):
+class SystemManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage Storage System resources.
     """

--- a/pyds8k/resources/ds8k/v1/tserep.py
+++ b/pyds8k/resources/ds8k/v1/tserep.py
@@ -17,15 +17,13 @@
 """
 TSE Rep interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_TSEREP
 from .common.base import SingletonBase, SingletonBaseManager
 from .pools import Pool, PoolManager
 
 
-@six.add_metaclass(ResourceMeta)
-class TSERep(SingletonBase):
+class TSERep(SingletonBase, metaclass=ResourceMeta):
     resource_type = DS8K_TSEREP
     # id_field = 'id'
     _template = {'cap': '',
@@ -45,8 +43,7 @@ class TSERep(SingletonBase):
         return super(TSERep, self).__getattr__(key)
 
 
-@six.add_metaclass(ManagerMeta)
-class TSERepManager(SingletonBaseManager):
+class TSERepManager(SingletonBaseManager, metaclass=ManagerMeta):
     """
     Manage TSE Rep resources.
     """

--- a/pyds8k/resources/ds8k/v1/users.py
+++ b/pyds8k/resources/ds8k/v1/users.py
@@ -17,14 +17,12 @@
 """
 User interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.types import DS8K_USER
 from .common.base import Base, ReadOnlyManager
 
 
-@six.add_metaclass(ResourceMeta)
-class User(Base):
+class User(Base, metaclass=ResourceMeta):
     resource_type = DS8K_USER
     id_field = 'name'
     _template = {'name': '',
@@ -33,8 +31,7 @@ class User(Base):
                  }
 
 
-@six.add_metaclass(ManagerMeta)
-class UserManager(ReadOnlyManager):
+class UserManager(ReadOnlyManager, metaclass=ManagerMeta):
     """
     Manage User resources.
     """

--- a/pyds8k/resources/ds8k/v1/volumes.py
+++ b/pyds8k/resources/ds8k/v1/volumes.py
@@ -17,7 +17,6 @@
 """
 Storage volume interface.
 """
-import six
 from pyds8k.base import ManagerMeta, ResourceMeta
 from .common.base import Base, BaseManager
 from .common import types
@@ -26,8 +25,7 @@ from .lss import LSS, LSSManager
 from .hosts import Host, HostManager
 
 
-@six.add_metaclass(ResourceMeta)
-class Volume(Base):
+class Volume(Base, metaclass=ResourceMeta):
     resource_type = types.DS8K_VOLUME
     # id_field = 'id'
 
@@ -127,8 +125,7 @@ class Volume(Base):
         self._stop_updating()
 
 
-@six.add_metaclass(ManagerMeta)
-class VolumeManager(BaseManager):
+class VolumeManager(BaseManager, metaclass=ManagerMeta):
     """
     Manage Storage Volume resources.
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests>=2.31.0
 configparser
-six

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import find_packages, setup
 
 import pyds8k
 
-install_requires = ['requests', 'configparser', 'six']
+install_requires = ['requests', 'configparser']
 
 setup(
     name='pyds8k',


### PR DESCRIPTION
Python 2 is EOS and Python >= 3.7 is supported, so six is no longer needed.