### PR TITLE
Remove configparser dependancy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=2.31.0
-configparser

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import find_packages, setup
 
 import pyds8k
 
-install_requires = ['requests', 'configparser']
+install_requires = ['requests']
 
 setup(
     name='pyds8k',


### PR DESCRIPTION
configparser was added for Python2, but unused because the backport version is not imported.

Python 2 is EOS and Python >= 3.7 is supported, so the backported configparser is no longer needed anyway.

The code to use configparser is not active and tests are skipped.