### PR TITLE
Remove MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-exclude  pyds8k/tests *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ Repository = "https://github.com/IBM/pyds8k.git"
 version = { attr = "pyds8k.version" } # Set in pyds8k/__init__.py
 
 [tool.setuptools.packages.find]
-exclude = ["cover", "images"]
+exclude = ["cover", "images", "docs"]
 
 [tool.ruff]
 # Same as Black.


### PR DESCRIPTION
The required version of setuptools supports managing via pyproject.toml tool.setuptools.packages.find.

Exclude docs directory.